### PR TITLE
chore(main): set plugin to full screen when activated

### DIFF
--- a/app/src/main/main.html
+++ b/app/src/main/main.html
@@ -4,7 +4,7 @@
   <require from="../task-bar/task-bar"></require>
 
   <div class="main">
-    <div class="left">
+    <div class="left ${pluginViewActivated ? 'left-plugin-view':''}">
       <div class="top">
         <h1 class="main-header" style="text-align:center">Monterey</h1>
         <div class="main-button-group">
@@ -16,7 +16,7 @@
       <project-list selected-project.two-way="selectedProject" disabled.bind="_activePluginScreen"></project-list>
     </div>
 
-    <div class="right">
+    <div class="right ${pluginViewActivated ? 'right-plugin-view':''}">
       <!-- list of tiles -->
       <tiles show.bind="!_activePluginScreen" view-model.ref="tilesVM" selected-project.bind="selectedProject"></tiles>
 

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -14,6 +14,7 @@ export class Main {
   _activePluginScreenModel;
   _activePluginScreen: string;
   tilesVM: Tiles;
+  pluginViewActivated : boolean;
 
   constructor(private projectFinder: ProjectFinder,
               private projectManager: ProjectManager,
@@ -56,6 +57,8 @@ export class Main {
 
     this._activePluginScreenModel = model;
     this._activePluginScreen = viewModelPath;
+    this.pluginViewActivated = true;
+
   }
 
   returnToPluginList() {
@@ -65,6 +68,7 @@ export class Main {
       }
     }
     this._activePluginScreen = '';
+    this.pluginViewActivated = false;
   }
 
   refreshTiles() {

--- a/app/src/plugins/app-launcher/screen.html
+++ b/app/src/plugins/app-launcher/screen.html
@@ -5,6 +5,9 @@
     <h1 class="plugin-title">App launcher</h1>
   </div>
   <div class="plugin-content-container">
+
+    <h3 class="project-title" if.bind="selectedProject.name">${selectedProject.name}</h3>
+
     <p>
       App launchers are configurable tiles that execute a cmd when clicked
     </p>

--- a/app/src/plugins/app-launcher/screen.html
+++ b/app/src/plugins/app-launcher/screen.html
@@ -6,7 +6,7 @@
   </div>
   <div class="plugin-content-container">
 
-    <h3 class="project-title" if.bind="selectedProject.name">${selectedProject.name}</h3>
+
 
     <p>
       App launchers are configurable tiles that execute a cmd when clicked

--- a/app/src/plugins/jspm/screen.html
+++ b/app/src/plugins/jspm/screen.html
@@ -1,10 +1,8 @@
 <template>
   <div class="plugin-title-container">
-    <h1 class="plugin-title">JSPM Package Manager</h1>
+    <h1 class="plugin-title">JSPM Package Manager<span class="project-title-plugin" if.bind="selectedProject.name">${' - '+selectedProject.name}</span></h1>
   </div>
   <div class="plugin-content-container">
-
-    <h3 class="project-title" if.bind="selectedProject.name">${selectedProject.name}</h3>
 
     <!-- forks -->
     <div class="alert alert-danger alert-dismissible" role="alert" if.bind="forks.length > 0">

--- a/app/src/plugins/jspm/screen.html
+++ b/app/src/plugins/jspm/screen.html
@@ -4,11 +4,15 @@
   </div>
   <div class="plugin-content-container">
 
+    <h3 class="project-title" if.bind="selectedProject.name">${selectedProject.name}</h3>
+
     <!-- forks -->
     <div class="alert alert-danger alert-dismissible" role="alert" if.bind="forks.length > 0">
       <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
       This project has forks. Click <a href="#" class="alert-link" click.delegate="showForks()">here</a> to get more information.
     </div>
+
+
 
     <!-- row of buttons -->
     <button click.delegate="installAll()" class="btn btn-primary">Install</button>

--- a/app/src/plugins/npm/screen.html
+++ b/app/src/plugins/npm/screen.html
@@ -1,10 +1,8 @@
 <template>
   <div class="plugin-title-container">
-    <h1 class="plugin-title">NPM Package Manager</h1>
+    <h1 class="plugin-title">NPM Package Manager<span class="project-title-plugin" if.bind="selectedProject.name">${' - '+selectedProject.name}</span></h1>
   </div>
   <div class="plugin-content-container">
-
-    <h3 class="project-title" if.bind="selectedProject.name">${selectedProject.name}</h3>
 
     <button click.delegate="installAll()" class="btn btn-primary">Install</button>
     <button click.delegate="updateSelected()" class="btn btn-primary">Update selected</button>

--- a/app/src/plugins/npm/screen.html
+++ b/app/src/plugins/npm/screen.html
@@ -3,6 +3,9 @@
     <h1 class="plugin-title">NPM Package Manager</h1>
   </div>
   <div class="plugin-content-container">
+
+    <h3 class="project-title" if.bind="selectedProject.name">${selectedProject.name}</h3>
+
     <button click.delegate="installAll()" class="btn btn-primary">Install</button>
     <button click.delegate="updateSelected()" class="btn btn-primary">Update selected</button>
     <button click.delegate="load()" class="btn btn-primary">Refresh</button>

--- a/app/src/plugins/preferences/screen.html
+++ b/app/src/plugins/preferences/screen.html
@@ -3,6 +3,7 @@
     <h1 class="plugin-title">Preferences</h1>
   </div>
   <div class="plugin-content-container">
+    <h3 class="project-title" if.bind="selectedProject.name">${selectedProject.name}</h3>
     <form validation-renderer="bootstrap-form">
       <div class="form-group">
         <label class="control-label" for="title">Github credentials</label>

--- a/app/src/plugins/preferences/screen.html
+++ b/app/src/plugins/preferences/screen.html
@@ -3,7 +3,6 @@
     <h1 class="plugin-title">Preferences</h1>
   </div>
   <div class="plugin-content-container">
-    <h3 class="project-title" if.bind="selectedProject.name">${selectedProject.name}</h3>
     <form validation-renderer="bootstrap-form">
       <div class="form-group">
         <label class="control-label" for="title">Github credentials</label>

--- a/app/src/plugins/project-info/screen.html
+++ b/app/src/plugins/project-info/screen.html
@@ -1,10 +1,8 @@
 <template>
   <div class="plugin-title-container">
-    <h1 class="plugin-title">Project information</h1>
+    <h1 class="plugin-title">Project information<span class="project-title-plugin" if.bind="selectedProject.name">${' - '+selectedProject.name}</span></h1>
   </div>
   <div class="plugin-content-container">
-
-    <h3 class="project-title" if.bind="selectedProject.name">${selectedProject.name}</h3>
 
     <button class="copy-btn btn btn-primary">Copy to clipboard</button>
 

--- a/app/src/plugins/project-info/screen.html
+++ b/app/src/plugins/project-info/screen.html
@@ -4,6 +4,8 @@
   </div>
   <div class="plugin-content-container">
 
+    <h3 class="project-title" if.bind="selectedProject.name">${selectedProject.name}</h3>
+
     <button class="copy-btn btn btn-primary">Copy to clipboard</button>
 
     <p class="copyable-item">

--- a/app/styles/pages/main.less
+++ b/app/styles/pages/main.less
@@ -146,6 +146,10 @@
 
   }
 
+  .left-plugin-view {
+    width: 0;
+  }
+
   .right {
     position: fixed;
     top: 0;
@@ -172,6 +176,9 @@
     }
   }
 
+  .right-plugin-view{
+    left: 0;
+  }
   project-list {
     position: absolute;
     bottom: 0;

--- a/app/styles/pages/main.less
+++ b/app/styles/pages/main.less
@@ -168,6 +168,10 @@
       text-transform: capitalize;
     }
 
+    .project-title-plugin {
+      text-transform: capitalize;
+    }
+
     .returnToPluginListBtn{
       position: absolute;
       top: 5px;


### PR DESCRIPTION
Suggestion, close it if you dont want it
Figured we could just hide the left menu since you cant really do anything when you are in a plugin-view anyways, that way we have more screen for the plugin to use

Video:
https://drive.google.com/file/d/0B_wM5SJf8IXoS3Z0UmY2d1RNMUE/view?usp=sharing

When not in a plugin with view
![image](https://cloud.githubusercontent.com/assets/2901416/16889421/9dde3706-4ae6-11e6-92e5-c8a28814a276.png)


When in a plugin with view
![image](https://cloud.githubusercontent.com/assets/2901416/16889436/b3743804-4ae6-11e6-9659-06570dddc944.png)
