### PR TITLE
chore(native modules): added script tag for rebuilding only

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "pack": "build --dir",
     "dist": "gulp clean-logs && build",
     "setup": "node utils -setup && node utils -rebuild-native",
+    "rebuild-native": "node utils -rebuild-native",
     "test-build": "gulp rename-index && build && gulp rename-index-back"
   },
   "directories": {

--- a/utils.js
+++ b/utils.js
@@ -14,7 +14,11 @@ var rebuildNative = () => {
   var childProcess = require('child_process');
   var path = require("path");
   var pathToElectron = path.join(__dirname, '/node_modules/electron-prebuilt/dist/electron');
+  console.log("Using electron for building:")
+  console.log(pathToElectron);
   var modulesPath = path.join(__dirname, '/app/node_modules');
+  console.log("Rebuilding native modules in:")
+  console.log(modulesPath)
 
   shouldRebuildNativeModules(pathToElectron)
     .then((shouldBuild) => {


### PR DESCRIPTION
Found out this today:
-running this will not rebuild like it should.
```node utils -rebuild-native```

For some reason it needs to be started from a script tag
So figured it could be usefull to have one for just the rebuilding too