### PR TITLE
chore(all): resolve some errors with TypeScript 2.1

### DIFF
--- a/app/src/plugins/aurelia-cli/index.ts
+++ b/app/src/plugins/aurelia-cli/index.ts
@@ -34,6 +34,8 @@ export class Plugin extends BasePlugin {
       project.favoriteCommands.push(new Command('au', ['run']));
       project.favoriteCommands.push(new Command('au', ['run', '--watch']));
     }
+
+    return project;
   }
 
   async getProjectInfoSections(project) {

--- a/app/src/plugins/dotnet/index.ts
+++ b/app/src/plugins/dotnet/index.ts
@@ -35,6 +35,8 @@ export class Plugin extends BasePlugin {
 
       project.favoriteCommands.push(new Command('dotnet', ['run']));
     }
+
+    return project;
   }
 
   async getProjectInfoSections(project: Project) {

--- a/app/src/plugins/gulp/index.ts
+++ b/app/src/plugins/gulp/index.ts
@@ -31,6 +31,8 @@ export class Plugin extends BasePlugin {
       project.favoriteCommands.push(new Command('gulp', ['watch']));
       project.favoriteCommands.push(new Command('gulp', ['build']));
     }
+
+    return project;
   }
 
   async getProjectInfoSections(project: Project) {

--- a/app/src/plugins/jspm/index.ts
+++ b/app/src/plugins/jspm/index.ts
@@ -35,6 +35,8 @@ export class Plugin extends BasePlugin {
     if (project.packageJSONPath) {
       await this.jspmDetection.findJspmConfig(project);
     }
+
+    return project;
   }
 
   async getProjectInfoSections(project: Project) {

--- a/app/src/plugins/npm/index.ts
+++ b/app/src/plugins/npm/index.ts
@@ -34,6 +34,7 @@ export class Plugin extends BasePlugin {
 
   async evaluateProject(project: Project) {
     await this.npmDetection.findPackageJSON(project);
+    return project;
   }
 
   async getProjectInfoSections(project: Project) {

--- a/app/src/plugins/typings/index.ts
+++ b/app/src/plugins/typings/index.ts
@@ -25,6 +25,8 @@ export class Plugin extends BasePlugin {
     if (project.isUsingTypings()) {
       project.favoriteCommands.push(new Command('node', ['node_modules/typings/dist/bin.js', 'install'], 'typings install'));
     }
+
+    return project;
   }
 
   async getProjectInfoSections(project: Project) {

--- a/app/src/plugins/webpack/index.ts
+++ b/app/src/plugins/webpack/index.ts
@@ -30,6 +30,8 @@ export class Plugin extends BasePlugin {
 
       project.favoriteCommands.push(new Command('npm', ['start']));
     }
+
+    return project;
   }
 
   async getProjectInfoSections(project: Project) {

--- a/app/src/scaffolding/aurelia-cli/run.ts
+++ b/app/src/scaffolding/aurelia-cli/run.ts
@@ -9,7 +9,7 @@ export class Run {
   finished = false;
   state;
   context: WorkflowContext;
-  promise: Promise<void>;
+  promise: Promise<{}>;
 
   constructor(private notification: Notification) {
   }

--- a/app/src/shared/github-api.ts
+++ b/app/src/shared/github-api.ts
@@ -38,7 +38,7 @@ export class GithubAPI {
    * Executes a request, throw error ({ status: number, message: string }) when statusCode
    * is something else than 200
    */
-  async execute(url: string) {
+  async execute(url: string): Promise<any> {
     return this.client.fetch(url)
     .then(response => {
       if (response.status !== 200) {

--- a/app/src/shared/monterey-registries.ts
+++ b/app/src/shared/monterey-registries.ts
@@ -6,7 +6,7 @@ import {RandomNumber}     from './random-number';
 
 @autoinject
 export class MontereyRegistries {
-  state;
+  state: ApplicationState;
   client: HttpClient;
   cache = {
     templates: null,
@@ -36,7 +36,7 @@ export class MontereyRegistries {
 
     return this.getClient().fetch(`project-templates.json`)
     .then(response => response.json())
-    .then(data => { this.cache.templates = data.templates; return data.templates; });
+    .then(data => { this.cache.templates = (data as any).templates; return (data as any).templates; });
   }
 
   async getGistRun() {
@@ -73,7 +73,8 @@ export class MontereyRegistries {
     let data = await this.getClient().fetch(`launchers/${platform}/${path}/launcher.json`)
     .then(response => response.json())
     .then(json => {
-      return json;
+      // should be valid because json is actually "any" and not "Response"
+      return json as any;
     });
 
     // Get the icon as a blob

--- a/app/src/shared/npm-api.ts
+++ b/app/src/shared/npm-api.ts
@@ -17,6 +17,6 @@ export class NPMAPI {
   async getLatest(repository: string) {
     return this.client.fetch(`${this.npmAPIUrl}-/package/${repository}/dist-tags`)
     .then(response => response.json())
-    .then(data => data.latest);
+    .then(data => (data as any).latest);
   }
 }


### PR DESCRIPTION
I've tried to build Monterey with TS 2.1.4 and got a lot of errors.
Apparently 2.1 is much more restrictive than 2.0..

All the plugins' `evaluateProject` functions are expected to return the project.
The `(data as any)` conversions look cheap but are actually valid since `response.json()` returns `Promise<any>`. TS thinks it returns `Promise<Response>` which is not the case.
